### PR TITLE
validate that wp versions match in release workflow

### DIFF
--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -99,8 +99,17 @@ jobs:
       - name: Setup Registry
         run: printf "\n//npm.pkg.github.com/:_authToken=${{ secrets.NEWFOLD_ACCESS_TOKEN }}" >> .npmrc
 
-      - name: npm install
+      - name: NPM Install
         run: npm install --legacy-peer-deps
+
+      - name: Validate WP Versions
+        if: ${{ (github.repository == 'newfold-labs/wp-plugin-web') && (github.event.release.prerelease == false) }}
+        run: |
+          wpEnvVersion=`grep "WordPress/WordPress#tags/" .wp-env.json | grep -Eo "[0-9\.]*"`
+          pluginHeaderTestedVersion=`grep "Tested up to:" wp-plugin-web.php | grep -Eo "[0-9\.]*"`
+          echo "wp-env version: $wpEnvVersion"
+          echo "Plugin header tested version: $pluginHeaderTestedVersion"
+          [[ "$wpEnvVersion" == "$pluginHeaderTestedVersion" ]] || exit 1
 
       - name: Build JavaScript
         run: npm run build

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress#tags/6.3.1",
+  "core": "WordPress/WordPress#tags/6.3.2",
   "config": {
     "WP_DEBUG": true,
     "WP_DEBUG_LOG": true,

--- a/wp-plugin-web.php
+++ b/wp-plugin-web.php
@@ -14,7 +14,7 @@
  * Version:           1.3.0
  * Requires at least: 4.7
  * Requires PHP:      5.6
- * Tested up to:      6.3.1
+ * Tested up to:      6.3.2
  * Author:            Web.com
  * Author URI:        https://web.com
  * Text Domain:       wp-plugin-web


### PR DESCRIPTION
In the release workflow, we're adding a job to check the wp version against the tested version the plugin reports.

We want this to always be the latest version so users have confidence in updates.

This addresses [PRESS1-192](https://jira.newfold.com/browse/PRESS1-192)