### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -5,10 +5,15 @@ on:
     types:
       - opened
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions: {} # Project updates use secrets.PROJECT_TOKEN, not GITHUB_TOKEN.
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,6 +13,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {} # Project updates use secrets.PROJECT_TOKEN, not GITHUB_TOKEN.
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -8,13 +8,15 @@ on:
         required: true
         default: ""
 
-permissions:
-  issues: write
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   create-milestone:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required to create milestones via the GitHub REST API using GITHUB_TOKEN.
 
     steps:
       - name: Create Milestone

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   create-milestone:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write # Required to create milestones via the GitHub REST API using GITHUB_TOKEN.
 

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -5,11 +5,16 @@ on:
     types:
       - deleted
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   delete:
     name: On Delete Release
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'newfold-labs/wp-plugin-web' }}
+    permissions: {} # Purge step calls Cloudflare only; GITHUB_TOKEN is unused.
     steps:
 
       - name: Clear cache for release API

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -14,6 +14,7 @@ jobs:
     name: On Delete Release
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'newfold-labs/wp-plugin-web' }}
+    timeout-minutes: 10
     permissions: {} # Purge step calls Cloudflare only; GITHUB_TOKEN is unused.
     steps:
 

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -15,10 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repository and compute PHP file diffs.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -23,6 +23,7 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to clone the repository and compute PHP file diffs.
     steps:

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -18,6 +18,7 @@ permissions: {}
 jobs:
   lint-yml:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read # Required to clone the repository.
     steps:

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -10,9 +10,16 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   lint-yml:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repository.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: read
+      contents: read # Required to clone the repository.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/playwright-tests-beta.yml
+++ b/.github/workflows/playwright-tests-beta.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      contents: read
+      contents: read # Required to clone the repository.
 
     steps:
       - name: Checkout

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -26,7 +26,7 @@ jobs:
       dist: ${{ steps.workflow.outputs.DIST }}
       package: ${{ steps.workflow.outputs.PACKAGE }}
     permissions:
-      contents: read
+      contents: read # Required to clone the repository.
 
     steps:
       - name: Checkout
@@ -112,7 +112,7 @@ jobs:
     timeout-minutes: 60
     needs: build
     permissions:
-      contents: read
+      contents: read # Required to clone the repository.
 
     steps:
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {} # Repository dispatch uses secrets.WEBHOOK_TOKEN, not GITHUB_TOKEN.
     steps:
 

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Repository dispatch uses secrets.WEBHOOK_TOKEN, not GITHUB_TOKEN.
     steps:
 
       - name: Set Package

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: On Push
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read # Required to clone the private repository.
     steps:

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -16,10 +16,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: On Push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the private repository.
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -13,10 +13,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to check out the repository and upload the release zip with actions/upload-release-asset (GitHub docs: contents write creates/uploads release assets).
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write # Required to check out the repository and upload the release zip with actions/upload-release-asset (GitHub docs: contents write creates/uploads release assets).
     steps:

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -16,6 +16,7 @@ permissions: {}
 jobs:
   wp-i18n:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # Required to check out the repository and push i18n updates via ad-m/github-push-action.
     steps:

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -8,9 +8,16 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   wp-i18n:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to check out the repository and push i18n updates via ad-m/github-push-action.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 12 (`add-to-project.yml`, `create-milestone.yml`, `delete-release.yml`, `lint-php.yml`, `lint-yml.yml`, `playwright-matrix.yml`, `playwright-tests-beta.yml`, `playwright-tests.yml`, `satis-webhook.yml`, `upload-artifact-on-push.yml`, `upload-asset-on-release.yml`, `wp-i18n.yml`) |
| Verified glob path | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-plugin-web/.github/workflows/*.yml` |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `18c8d27` |
| Timeouts commit | `d1afcc2` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `add-to-project.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `create-milestone.yml` (replaced prior workflow-level permissions with the standard empty block + comment pattern) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `delete-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-yml.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-artifact-on-push.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-asset-on-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `wp-i18n.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| wp-i18n.yml | 1 job was missing a scoped `permissions:` directive | wp-i18n | `contents: write` [3] |
| upload-asset-on-release.yml | 1 job was missing a scoped `permissions:` directive | — | `build` / On Release -> `contents: write` [3] |
| upload-artifact-on-push.yml | 1 job was missing a scoped `permissions:` directive | — | `build` / On Push -> `contents: read` [3] |
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint-yml.yml | 1 job was missing a scoped `permissions:` directive | lint-yml | `contents: read` [3] |
| lint-php.yml | 1 job was missing a scoped `permissions:` directive | — | `phpcs` / Run PHP Code Sniffer -> `contents: read` [3] |
| delete-release.yml | 1 job was missing a scoped `permissions:` directive | delete | `permissions: {}` [3] |
| create-milestone.yml | 1 job was missing a scoped `permissions:` directive (permissions were previously only at workflow level) | create-milestone | `issues: write` [3] |
| add-to-project.yml | 1 job was missing a scoped `permissions:` directive | add-to-project | `permissions: {}` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `create-milestone.yml` :: `create-milestone`: BEFORE workflow-level `issues: write` + `contents: read` -> AFTER job-level `issues: write` only with top-level `permissions: {}` -- `contents: read` was unnecessary because the workflow does not check out the repository; milestone creation uses the Issues API (`issues: write`). -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| wp-i18n.yml | wp-i18n | `30` | i18n validation/build plus optional commit/push should finish well under a half hour; caps runaway runs. |
| — | — | — | `upload-asset-on-release.yml` :: `build` / On Release -> `45` -- release packaging, npm/composer build, zip creation, GitHub release upload, and R2 upload can be heavier than a quick lint job. |
| — | — | — | `upload-artifact-on-push.yml` :: `build` / On Push -> `45` -- same style of build/packaging as the on-push artifact workflow; aligns with expected compile time headroom. |
| satis-webhook.yml | webhook | `10` | short webhook/dispatch job; timeout is a safety net only. |
| lint-yml.yml | lint-yml | `15` | yamllint across workflow files should be fast; small cap prevents hangs. |
| lint-php.yml | phpcs | `30` | composer install + PHPCS over diffs may take longer on cold cache; moderate cap. |
| delete-release.yml | delete | `10` | single external cache purge curl; safety cap. |
| create-milestone.yml | create-milestone | `10` | one GitHub API POST + minimal shell; safety cap. |
| add-to-project.yml | add-to-project | `10` | add-to-project action only; safety cap. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Local commits were created with `git commit --no-gpg-sign` because commit signing failed under the tool sandbox (GPG/keybox access). Your normal environment may want to re-sign or amend if signed commits are required. |
| 2 | `wp-i18n.yml` still nests `pull_request` under `push` in the `on:` mapping; that structure is likely unintentional for “push OR pull_request” triggers and is worth a human YAML/trigge r fix outside this permissions pass. |
| 3 | Third-party actions (`peter-evans/repository-dispatch`, `actions/add-to-project`, `ad-m/github-push-action`, `actions/upload-release-asset`) were assessed via their inputs/tokens as wired in-repo; PAT usage (`secrets.WEBHOOK_TOKEN`, `secrets.PROJECT_TOKEN`) avoids expanding default `GITHUB_TOKEN` scopes for those paths. |


